### PR TITLE
Support non-string type for variables

### DIFF
--- a/src/main/scala/com/yotpo/metorikku/Job.scala
+++ b/src/main/scala/com/yotpo/metorikku/Job.scala
@@ -54,7 +54,7 @@ case class Job(val config: Configuration) {
 
   private def registerVariables(variables: Option[Map[String, String]], sparkSession: SparkSession): Unit = {
     variables.getOrElse(Map()).foreach({ case (key, value) => {
-      sparkSession.sql(s"set $key='$value'")
+      sparkSession.sql(s"set $key=$value")
     }
     })
   }


### PR DESCRIPTION
I found variables are always string type. However, I also want to use variables as number or column names.
We can still set a variable to a string by escaping quote in `yaml` file.