### PR TITLE
feat(jdbc): Expand JDBC output configuration options

### DIFF
--- a/schemas/job_schema.json
+++ b/schemas/job_schema.json
@@ -160,7 +160,12 @@
             "connectionUrl": { "type": "string" },
             "user": { "type": "string" },
             "password": { "type": "string" },
-            "driver": { "type": "string" }
+            "driver": { "type": "string" },
+            "sessionInitStatement": { "type": "string" },
+            "truncate": { "type": "string" },
+            "cascadeTruncate": { "type": "string" },
+            "createTableOptions": { "type": "string" },
+            "createTableColumnTypes": { "type": "string" }
           },
           "required": [
             "connectionUrl",

--- a/src/main/scala/com/yotpo/metorikku/configuration/job/output/JDBC.scala
+++ b/src/main/scala/com/yotpo/metorikku/configuration/job/output/JDBC.scala
@@ -3,7 +3,12 @@ package com.yotpo.metorikku.configuration.job.output
 case class JDBC(connectionUrl: String,
                 user: String,
                 password: String,
-                driver: String
+                driver: String,
+                sessionInitStatement: Option[String],
+                truncate: Option[String],
+                cascadeTruncate: Option[String],
+                createTableOptions: Option[String],
+                createTableColumnTypes: Option[String]
                ) {
   require(Option(connectionUrl).isDefined, "JDBC connection: connection url is mandatory")
   require(Option(user).isDefined, "JDBC connection: user is mandatory")

--- a/src/main/scala/com/yotpo/metorikku/output/writers/jdbc/JDBCOutputWriter.scala
+++ b/src/main/scala/com/yotpo/metorikku/output/writers/jdbc/JDBCOutputWriter.scala
@@ -23,6 +23,21 @@ class JDBCOutputWriter(props: Map[String, String], jdbcConf: Option[JDBC]) exten
         connectionProperties.put("user", jdbcConf.user)
         connectionProperties.put("password", jdbcConf.password)
         connectionProperties.put("driver", jdbcConf.driver)
+        if (jdbcConf.truncate.isDefined) {
+          connectionProperties.put("truncate", jdbcConf.truncate.get)
+        }
+        if (jdbcConf.cascadeTruncate.isDefined) {
+          connectionProperties.put("cascadeTruncate", jdbcConf.cascadeTruncate.get)
+        }
+        if (jdbcConf.createTableColumnTypes.isDefined) {
+          connectionProperties.put("createTableColumnTypes", jdbcConf.createTableColumnTypes.get)
+        }
+        if (jdbcConf.createTableOptions.isDefined) {
+          connectionProperties.put("createTableOptions", jdbcConf.createTableOptions.get)
+        }
+        if (jdbcConf.sessionInitStatement.isDefined) {
+          connectionProperties.put("sessionInitStatement", jdbcConf.sessionInitStatement.get)
+        }
         var df = dataFrame
         val writer = df.write.format(jdbcConf.driver)
           .mode(dbOptions.saveMode)


### PR DESCRIPTION
This patch expands output JDBC options to support all available options in the Spark JDBC datasource.

Since all additional configurations are registered as optional and the default behavior is identical to the current master, it should not create any regression issue for current users and it provides additional capabilities to handle some corner cases such as specifying engine specific options when used with a MySQL database or truncating instead of droping an existing table in overwrite mode to preserve existing index definitions or triggers.